### PR TITLE
fix: add Lambda waiter to support new Lambda statusses

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@dazn/lambda-powertools-logger": "^1.15.2",
     "async-retry": "^1.3.1",
-    "aws-sdk": "^2.603.0",
+    "aws-sdk": "^2.1248.0",
     "lodash": "^4.17.15",
     "uuid": "^3.3.3"
   },

--- a/src/functions/loop.js
+++ b/src/functions/loop.js
@@ -42,6 +42,7 @@ const updateEnvVar = async (functionName, envVars) => {
 		Environment: envVars
 	};
 	await Lambda.updateFunctionConfiguration(req).promise();
+  await Lambda.waitFor("functionUpdatedV2", {FunctionName: functionName,}).promise();
 };
 
 const invoke = async (functionName, payload) => {

--- a/template.yml
+++ b/template.yml
@@ -35,6 +35,7 @@ Resources:
               - lambda:GetFunctionConfiguration
               - lambda:UpdateFunctionConfiguration
               - lambda:InvokeFunction
+              - lambda:GetFunction
             Resource: "*"
 
   LoopLogGroup:


### PR DESCRIPTION
With the introduction of [Lambda states](https://docs.aws.amazon.com/lambda/latest/dg/functions-states.html) the Loop lambda keeps running into errors 
```
  "errorType": "ResourceConflictException",
  "errorMessage": "The operation cannot be performed at this time. An update is in progress for resource:
 ```
 
The solution is to use the new waiter (updated sdk) that polls the function status and waits till it is in the correct state. 
This has been manually tested on my account. 